### PR TITLE
NGC-1229 - Use only the exclusion service to drive the decision for c…

### DIFF
--- a/app/uk/gov/hmrc/ngc/orchestration/binders/Binders.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/binders/Binders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,5 +24,3 @@ object NinoBinder extends SimpleObjectBinder[Nino](Nino.apply, _.value)
 object Binders {
   implicit val ninoBinder = NinoBinder
 }
-
-

--- a/app/uk/gov/hmrc/ngc/orchestration/config/AppContext.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/config/AppContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ngc/orchestration/config/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/config/microserviceGlobal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ngc/orchestration/config/microserviceWiring.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/config/microserviceWiring.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ngc/orchestration/connectors/AuthConnector.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/connectors/AuthConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,6 @@ trait AuthConnector {
     val credStrength = (jsValue \ "credentialStrength").as[String]
     credStrength != credStrengthStrong
   }
-
 
 }
 

--- a/app/uk/gov/hmrc/ngc/orchestration/connectors/GenericConnector.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/connectors/GenericConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.ngc.orchestration.connectors
 
+import play.api.Logger
 import play.api.libs.json._
 import uk.gov.hmrc.ngc.orchestration.config.WSHttp
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpPost, HttpResponse}
@@ -33,6 +34,7 @@ trait GenericConnector {
 
   def doGet(host:String, path:String, port:Int, hc: HeaderCarrier): Future[JsValue] = {
     implicit val hcHeaders = addAPIHeaders(hc)
+    Logger.warn(s"transport: HC received is ${hc.authorization} for path $path")
     http.GET[JsValue](buildUrl(host, port, path))
   }
 

--- a/app/uk/gov/hmrc/ngc/orchestration/controllers/AsyncController.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/controllers/AsyncController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ngc/orchestration/controllers/AsyncIntegration.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/controllers/AsyncIntegration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ngc/orchestration/controllers/SandboxPoll.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/controllers/SandboxPoll.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ngc/orchestration/controllers/action/AccountAccessControl.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/controllers/action/AccountAccessControl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,4 +108,3 @@ object AccountAccessControlCheckAccessOff extends AccountAccessControlWithHeader
 
   val accessControl: AccountAccessControl = AccountAccessControlSandbox
 }
-

--- a/app/uk/gov/hmrc/ngc/orchestration/controllers/error.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/controllers/error.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,6 @@ case object ErrorNinoInvalid extends ErrorResponse(400, "NINO_INVALID", "The pro
 case object ErrorUnauthorizedNoNino extends ErrorResponse(401, "UNAUTHORIZED", "NINO does not exist on account")
 
 case object ErrorBadRequest extends ErrorResponse(400, "BAD_REQUEST", "Invalid POST request")
-
-//case object ErrorUnauthorizedMicroService extends ErrorResponse(401, "UNAUTHORIZED", "Unauthorized to access resource")
-
-//case object ErrorUnauthorizedWeakCredStrength extends ErrorResponse(401, "WEAK_CRED_STRENGTH", "Credential Strength on account does not allow access")
 
 case object MandatoryResponse extends ErrorResponse(500, "MANDATORY", "Mandatory data not found")
 

--- a/app/uk/gov/hmrc/ngc/orchestration/domain/OrchestrationResult.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/domain/OrchestrationResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ngc/orchestration/domain/PreFlightCheck.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/domain/PreFlightCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/ngc/orchestration/services/OrchestrationService.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/services/OrchestrationService.scala
@@ -94,7 +94,7 @@ trait LiveOrchestrationService extends OrchestrationService with Auditor {
   private def buildResponse(inputRequest:JsValue, nino: String, year: Int, journeyId: Option[String])(implicit hc: HeaderCarrier, ex: ExecutionContext) : Future[Seq[JsObject]] = {
     val futuresSeq: Seq[Future[Option[Result]]] = Seq(
       TaxSummary(genericConnector, journeyId),
-      TaxCreditSummary(genericConnector, journeyId),
+      TaxCreditSummary(authConnector, genericConnector, journeyId),
       TaxCreditsSubmissionState(genericConnector, journeyId),
       PushRegistration(genericConnector, inputRequest, journeyId)
     ).map(item => item.execute(nino, year))

--- a/app/uk/gov/hmrc/ngc/orchestration/services/TimedEvent.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/services/TimedEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2016 HM Revenue & Customs
+# Copyright 2017 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ngc/orchestration/controllers/OrchestrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/ngc/orchestration/controllers/OrchestrationControllerSpec.scala
@@ -26,6 +26,7 @@ import play.api.mvc.{Request, Result}
 import play.api.test.{FakeApplication, FakeRequest}
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.ngc.orchestration.domain.{Accounts, PreFlightCheckResponse}
 import uk.gov.hmrc.play.asyncmvc.model.AsyncMvcSession
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import uk.gov.hmrc.play.http._
@@ -313,44 +314,44 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
     }
   }
 
-//  "startup live controller authentication " should {
-//
-//    "return unauthorized when authority record does not contain a NINO" in new AuthWithoutNino {
-//      testNoNINO(await(controller.startup(nino)(emptyRequestWithHeader)))
-//    }
-//
-//    "return 401 result with json status detailing low CL on authority" in new AuthWithLowCL {
-//      testLowCL(await(controller.startup(nino)(emptyRequestWithHeader)))
-//    }
-//
-//    "return status code 406 when the headers are invalid" in new Success {
-//      val result = await(controller.startup(nino)(emptyRequest))
-//      status(result) shouldBe 406
-//    }
-//  }
-//
-//  "sandbox controller " should {
-//
-//    "return the PreFlightCheckResponse response from a static resource" in new SandboxSuccess {
-//      val result = await(controller.preFlightCheck()(requestWithAuthSession.withBody(versionBody)))
-//      status(result) shouldBe 200
-//      val journeyIdRetrieve: String = (contentAsJson(result) \ "accounts" \ "journeyId").as[String]
-//      contentAsJson(result) shouldBe Json.toJson(PreFlightCheckResponse(upgradeRequired = false, Accounts(Some(nino), None, routeToIV = false, routeToTwoFactor = false, journeyIdRetrieve)))
-//    }
-//
-//    "return startup response from a static resource" in new SandboxSuccess {
-//      val result = await(controller.startup(nino)(requestWithAuthSession))
-//      status(result) shouldBe 200
-//      contentAsJson(result) shouldBe TestData.sandboxStartupResponse
-//    }
-//
-//    "return poll response from a static resource" in new SandboxSuccess {
-//      val result = await(controller.poll(nino)(requestWithAuthSession))
-//      status(result) shouldBe 200
-//      contentAsJson(result) shouldBe TestData.sandboxPollResponse
-//      result.header.headers.get("Cache-Control") shouldBe Some("max-age=14400")
-//    }
-//  }
+  "startup live controller authentication " should {
+
+    "return unauthorized when authority record does not contain a NINO" in new AuthWithoutNino {
+      testNoNINO(await(controller.startup(nino)(emptyRequestWithHeader)))
+    }
+
+    "return 401 result with json status detailing low CL on authority" in new AuthWithLowCL {
+      testLowCL(await(controller.startup(nino)(emptyRequestWithHeader)))
+    }
+
+    "return status code 406 when the headers are invalid" in new Success {
+      val result = await(controller.startup(nino)(emptyRequest))
+      status(result) shouldBe 406
+    }
+  }
+
+  "sandbox controller " should {
+
+    "return the PreFlightCheckResponse response from a static resource" in new SandboxSuccess {
+      val result = await(controller.preFlightCheck()(requestWithAuthSession.withBody(versionBody)))
+      status(result) shouldBe 200
+      val journeyIdRetrieve: String = (contentAsJson(result) \ "accounts" \ "journeyId").as[String]
+      contentAsJson(result) shouldBe Json.toJson(PreFlightCheckResponse(upgradeRequired = false, Accounts(Some(nino), None, routeToIV = false, routeToTwoFactor = false, journeyIdRetrieve)))
+    }
+
+    "return startup response from a static resource" in new SandboxSuccess {
+      val result = await(controller.startup(nino)(requestWithAuthSession))
+      status(result) shouldBe 200
+      contentAsJson(result) shouldBe TestData.sandboxStartupResponse
+    }
+
+    "return poll response from a static resource" in new SandboxSuccess {
+      val result = await(controller.poll(nino)(requestWithAuthSession))
+      status(result) shouldBe 200
+      contentAsJson(result) shouldBe TestData.sandboxPollResponse
+      result.header.headers.get("Cache-Control") shouldBe Some("max-age=14400")
+    }
+  }
 
   val token = "Bearer 123456789"
   def performStartup(inputBody: String, controller: NativeAppsOrchestrationController, testSessionId: String, nino: Nino) = {
@@ -388,8 +389,6 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
 
     // Verify the Id within the session matches the expected test Id.
     val session = startupResponse.session.get(controller.AsyncMVCSessionId)
-
-println(" SESSION RETURNED FROM STARTUP IS " + session)
 
     val jsonSession = Json.parse(session.get).as[AsyncMvcSession]
     jsonSession.id shouldBe testSessionId

--- a/test/uk/gov/hmrc/ngc/orchestration/controllers/OrchestrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/ngc/orchestration/controllers/OrchestrationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import play.api.mvc.{Request, Result}
 import play.api.test.{FakeApplication, FakeRequest}
 import play.api.test.Helpers._
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.ngc.orchestration.domain.{Accounts, PreFlightCheckResponse}
 import uk.gov.hmrc.play.asyncmvc.model.AsyncMvcSession
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import uk.gov.hmrc.play.http._
@@ -93,13 +92,6 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
 
   "async live controller to verify different json attribute response values based on service responses" should {
 
-    "not return taxCreditSummary attribute when 999/auth call fails" in new AuthenticateRenewal {
-      val jsonMatch = Seq(TestData.taxSummary(), TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((a, b) => a ++ b)
-
-      invokeStartupAndPollForResult(controller, "async_native-apps-api-id-AuthenticateRenewal", Nino("CS700100A"),
-        jsonMatch)(versionRequest)
-    }
-
     "return bad request when the session auth-token does not match the HC authorization header" in new SessionChecker {
       val body :JsValue= Json.parse("""{"token":"123456"}""")
       val requestWithSessionKeyAndIdBody = FakeRequest().withSession(
@@ -135,87 +127,48 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
           jsonMatch)(versionRequest)
       }
 
-    "first call fail to exclusion decision with 2nd call returning successfully - validate retry mechanism" in new FailWithRetrySuccess {
-      val jsonMatch = Seq(TestData.taxSummary(), TestData.taxCreditSummary, TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
+    "return no taxCreditSummary attribute when exclusion service throws 400 exception" in new ExclusionException {
+      override val testId = "BadRequest"
 
-      invokeStartupAndPollForResult(controller, "async_native-apps-api-id-FailWithRetrySuccess", Nino("CS700100A"),
-        jsonMatch)(versionRequest)
-
-      invokeCount shouldBe 2
-    }
-
-    "return an empty taxCreditSummary block when exclusion service throws exceptions" in new ExclusionException {
-      val jsonMatch = Seq(TestData.taxSummary(), TestData.taxCreditSummaryEmpty, TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
-
-      invokeStartupAndPollForResult(controller, "async_native-apps-api-id-ExclusionException", Nino("CS700100A"),
-        jsonMatch)(versionRequest)
-    }
-
-    "return no taxCreditSummary block when auth/9999 service returns 404 response" in new TestGenericController {
-      override val statusCode : Option[Int] = Some(404)
-      override val exception: Option[Exception] = None
-      override val exceptionControl: Boolean = false
-      override val mapping:Map[String, Boolean] = servicesAuthFailMap
-      override lazy val test_id: String = s"test_id_testOrchestrationDecisionFailure_$time"
-      override val taxSummaryData: JsValue = TestData.taxSummaryData()
+      override lazy val decisionFailureException = Some(new BadRequestException("Controlled 404"))
 
       val jsonMatch = Seq(TestData.taxSummary(), TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
 
-      invokeStartupAndPollForResult(controller, s"async_native-apps-api-id-test_id_testOrchestrationDecisionFailure_$time", Nino("CS700100A"),
+      invokeStartupAndPollForResult(controller, s"async_native-apps-api-id-$testId", Nino("CS700100A"),
         jsonMatch)(versionRequest)
     }
 
-    "return no taxCreditSummary block when auth/9999 service returns 500 response" in new TestGenericController {
-      override val statusCode: Option[Int] = Some(500)
-      override val exception: Option[Exception] = None
-      override val exceptionControl: Boolean = false
-      override val mapping:Map[String, Boolean] = servicesAuthFailMap
-      override lazy val test_id: String = s"test_id_testOrchestrationDecisionFailure_$time"
-      override val taxSummaryData: JsValue = TestData.taxSummaryData()
+    "return no taxCreditSummary attribute when exclusion service throws 404 exception" in new ExclusionException {
+      override val testId = "NotFound"
+
+      override lazy val decisionFailureException = Some(new NotFoundException("Controlled 404"))
 
       val jsonMatch = Seq(TestData.taxSummary(), TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
 
-      invokeStartupAndPollForResult(controller, s"async_native-apps-api-id-test_id_testOrchestrationDecisionFailure_$time", Nino("CS700100A"),
+      invokeStartupAndPollForResult(controller, s"async_native-apps-api-id-$testId", Nino("CS700100A"),
         jsonMatch)(versionRequest)
     }
 
-    "return empty taxCreditSummary block when auth/9999 service returns 200 and tax-credit-decision fails with 404 response" in new TestGenericController {
+    "return no taxCreditSummary attribute when exclusion service throws 401 exception" in new ExclusionException {
+      override val testId = "Unauthorized"
+
+      override lazy val decisionFailureException = Some(new Upstream4xxResponse("Controlled 404", 401, 401))
+
+      val jsonMatch = Seq(TestData.taxSummary(), TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
+
+      invokeStartupAndPollForResult(controller, s"async_native-apps-api-id-$testId", Nino("CS700100A"),
+        jsonMatch)(versionRequest)
+    }
+
+
+    "return empty taxCreditSummary block tax-credit-decision fails with 404 response" in new TestGenericController {
       override val statusCode: Option[Int] = None
       override val exception:Option[Exception]=Some(new NotFoundException("controlled explosion"))
-      override val exceptionControl: Boolean = false
       override val mapping:Map[String, Boolean] = servicesSuccessMap ++ Map("/income/CS700100A/tax-credits/tax-credits-decision" -> false)
       override lazy val test_id: String = s"test_id_testOrchestrationDecisionFailure_$time"
       override val taxSummaryData: JsValue = TestData.taxSummaryData()
 
-      val jsonMatch = Seq(TestData.taxSummary(), TestData.taxCreditSummaryEmpty, TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
-
-      invokeStartupAndPollForResult(controller, s"async_native-apps-api-id-test_id_testOrchestrationDecisionFailure_$time", Nino("CS700100A"),
-        jsonMatch)(versionRequest)
-    }
-
-    "return empty taxCreditSummary block when auth/9999 service returns 200 and tax-credit-decision fails with 403 response" in new TestGenericController {
-      override val statusCode: Option[Int] = None
-      override val exception:Option[Exception]=Some(new BadRequestException("controlled explosion"))
-      override val exceptionControl: Boolean = false
-      override val mapping:Map[String, Boolean] = servicesSuccessMap ++ Map("/income/CS700100A/tax-credits/tax-credits-decision" -> false)
-      override lazy val test_id: String = s"test_id_testOrchestrationDecisionFailure_$time"
-      override val taxSummaryData: JsValue = TestData.taxSummaryData()
-
-      val jsonMatch = Seq(TestData.taxSummary(), TestData.taxCreditSummaryEmpty, TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
-
-      invokeStartupAndPollForResult(controller, s"async_native-apps-api-id-test_id_testOrchestrationDecisionFailure_$time", Nino("CS700100A"),
-        jsonMatch)(versionRequest)
-    }
-
-    "return empty taxCreditSummary block when auth/9999 service returns 200 and tax-credit-decision fails with 500 response" in new TestGenericController {
-      override val statusCode: Option[Int] = None
-      override val exception:Option[Exception]=Some(new BadRequestException("controlled explosion"))
-      override val exceptionControl: Boolean = false
-      override val mapping:Map[String, Boolean] = servicesSuccessMap ++ Map("/income/CS700100A/tax-credits/tax-credits-decision" -> false)
-      override lazy val test_id: String = s"test_id_testOrchestrationDecisionFailure_$time"
-      override val taxSummaryData: JsValue = TestData.taxSummaryData()
-
-      val jsonMatch = Seq(TestData.taxSummary(), TestData.taxCreditSummaryEmpty, TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
+      val jsonMatch = Seq(TestData.taxSummary(), TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
 
       invokeStartupAndPollForResult(controller, s"async_native-apps-api-id-test_id_testOrchestrationDecisionFailure_$time", Nino("CS700100A"),
         jsonMatch)(versionRequest)
@@ -224,7 +177,6 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
     "return taxCreditSummary block when submission state returns a non 200 response" in new TestGenericController {
       override val statusCode: Option[Int] = None
       override val exception:Option[Exception]=Some(new BadRequestException("controlled explosion"))
-      override val exceptionControl: Boolean = false
       override val mapping:Map[String, Boolean] = servicesSuccessMap ++ Map("/income/tax-credits/submission/state/enabled" -> false)
       override lazy val test_id: String = s"test_id_testOrchestrationDecisionFailure_$time"
       override val taxSummaryData: JsValue = TestData.taxSummaryData()
@@ -238,7 +190,6 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
     "return empty tax-credit-summary response when retrieval of tax-summary returns non 200 response and push-registration executed successfully" in new TestGenericController {
       override val statusCode: Option[Int] = None
       override val exception:Option[Exception]=Some(new BadRequestException("controlled explosion"))
-      override val exceptionControl: Boolean = false
       override val mapping:Map[String, Boolean] = servicesSuccessMap ++ Map("/income/CS700100A/tax-summary/2016" -> false)
       override lazy val test_id: String = s"test_id_testOrchestrationDecisionFailure_$time"
       override val taxSummaryData: JsValue = TestData.taxSummaryData()
@@ -251,10 +202,9 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
       pushRegistrationInvokeCount shouldBe 1
     }
 
-    "return empty tax-credit-summary response when retrieval of tax-summary returns non 200 and empty taxCreditSummary when retrieval of tax-credit-summary returns non 200 response" in new TestGenericController {
+    "return empty taxSummary attribute when tax-summary returns non 200 response and empty taxCreditSummary when retrieval of tax-credit-summary returns non 200 response" in new TestGenericController {
       override val statusCode: Option[Int] = None
       override val exception:Option[Exception]=Some(new BadRequestException("controlled explosion"))
-      override val exceptionControl: Boolean = false
       override val mapping:Map[String, Boolean] = servicesSuccessMap ++
         Map(
           "/income/CS700100A/tax-summary/2016" -> false,
@@ -278,7 +228,6 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
       override val mapping :Map[String, Boolean] = servicesSuccessMap ++ Map("/income/CS700100A/tax-credits/tax-credits-summary" -> false)
       override lazy val test_id: String = s"test_id_testOrchestrationDecisionFailure_$time"
       override val taxSummaryData: JsValue = TestData.taxSummaryData()
-      override val exceptionControl: Boolean = false
 
       val jsonMatch = Seq(TestData.taxSummary(), TestData.taxCreditSummaryEmpty, TestData.submissionStateOn, TestData.statusComplete).foldLeft(Json.obj())((b, a) => b ++ a)
 
@@ -304,7 +253,6 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
             override lazy val test_id = s"test_id_concurrent_$counter"
             override val exception: Option[Exception] = None
             override val statusCode: Option[Int] = None
-            override val exceptionControl: Boolean = false
             override val mapping: Map[String, Boolean] = servicesSuccessMap
             override val taxSummaryData: JsValue = TestData.taxSummaryData(Some(test_id))
           }
@@ -313,7 +261,7 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
         excuteParallelAsyncTasks(createController, "async_native-apps-api-id-test_id_concurrent")
       }
 
-      "successfully process all concurrent requests with decision retry, once all tasks are complete verify the throttle value is 0" in {
+      "successfully process all concurrent requests, once all tasks are complete verify the throttle value is 0" in {
 
         def createController(counter: Int) = {
 
@@ -322,7 +270,6 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
             override lazy val test_id = s"test_id_concurrent_with_retry_$counter"
             override val exception: Option[Exception] = None
             override val statusCode: Option[Int] = None
-            override val exceptionControl: Boolean = true
             override val mapping: Map[String, Boolean] = servicesSuccessMap
             override val taxSummaryData: JsValue = TestData.taxSummaryData(Some(test_id))
           }
@@ -366,44 +313,44 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
     }
   }
 
-  "startup live controller authentication " should {
-
-    "return unauthorized when authority record does not contain a NINO" in new AuthWithoutNino {
-      testNoNINO(await(controller.startup(nino)(emptyRequestWithHeader)))
-    }
-
-    "return 401 result with json status detailing low CL on authority" in new AuthWithLowCL {
-      testLowCL(await(controller.startup(nino)(emptyRequestWithHeader)))
-    }
-
-    "return status code 406 when the headers are invalid" in new Success {
-      val result = await(controller.startup(nino)(emptyRequest))
-      status(result) shouldBe 406
-    }
-  }
-
-  "sandbox controller " should {
-
-    "return the PreFlightCheckResponse response from a static resource" in new SandboxSuccess {
-      val result = await(controller.preFlightCheck()(requestWithAuthSession.withBody(versionBody)))
-      status(result) shouldBe 200
-      val journeyIdRetrieve: String = (contentAsJson(result) \ "accounts" \ "journeyId").as[String]
-      contentAsJson(result) shouldBe Json.toJson(PreFlightCheckResponse(upgradeRequired = false, Accounts(Some(nino), None, routeToIV = false, routeToTwoFactor = false, journeyIdRetrieve)))
-    }
-
-    "return startup response from a static resource" in new SandboxSuccess {
-      val result = await(controller.startup(nino)(requestWithAuthSession))
-      status(result) shouldBe 200
-      contentAsJson(result) shouldBe TestData.sandboxStartupResponse
-    }
-
-    "return poll response from a static resource" in new SandboxSuccess {
-      val result = await(controller.poll(nino)(requestWithAuthSession))
-      status(result) shouldBe 200
-      contentAsJson(result) shouldBe TestData.sandboxPollResponse
-      result.header.headers.get("Cache-Control") shouldBe Some("max-age=14400")
-    }
-  }
+//  "startup live controller authentication " should {
+//
+//    "return unauthorized when authority record does not contain a NINO" in new AuthWithoutNino {
+//      testNoNINO(await(controller.startup(nino)(emptyRequestWithHeader)))
+//    }
+//
+//    "return 401 result with json status detailing low CL on authority" in new AuthWithLowCL {
+//      testLowCL(await(controller.startup(nino)(emptyRequestWithHeader)))
+//    }
+//
+//    "return status code 406 when the headers are invalid" in new Success {
+//      val result = await(controller.startup(nino)(emptyRequest))
+//      status(result) shouldBe 406
+//    }
+//  }
+//
+//  "sandbox controller " should {
+//
+//    "return the PreFlightCheckResponse response from a static resource" in new SandboxSuccess {
+//      val result = await(controller.preFlightCheck()(requestWithAuthSession.withBody(versionBody)))
+//      status(result) shouldBe 200
+//      val journeyIdRetrieve: String = (contentAsJson(result) \ "accounts" \ "journeyId").as[String]
+//      contentAsJson(result) shouldBe Json.toJson(PreFlightCheckResponse(upgradeRequired = false, Accounts(Some(nino), None, routeToIV = false, routeToTwoFactor = false, journeyIdRetrieve)))
+//    }
+//
+//    "return startup response from a static resource" in new SandboxSuccess {
+//      val result = await(controller.startup(nino)(requestWithAuthSession))
+//      status(result) shouldBe 200
+//      contentAsJson(result) shouldBe TestData.sandboxStartupResponse
+//    }
+//
+//    "return poll response from a static resource" in new SandboxSuccess {
+//      val result = await(controller.poll(nino)(requestWithAuthSession))
+//      status(result) shouldBe 200
+//      contentAsJson(result) shouldBe TestData.sandboxPollResponse
+//      result.header.headers.get("Cache-Control") shouldBe Some("max-age=14400")
+//    }
+//  }
 
   val token = "Bearer 123456789"
   def performStartup(inputBody: String, controller: NativeAppsOrchestrationController, testSessionId: String, nino: Nino) = {
@@ -441,6 +388,9 @@ class OrchestrationControllerSpec extends UnitSpec with WithFakeApplication with
 
     // Verify the Id within the session matches the expected test Id.
     val session = startupResponse.session.get(controller.AsyncMVCSessionId)
+
+println(" SESSION RETURNED FROM STARTUP IS " + session)
+
     val jsonSession = Json.parse(session.get).as[AsyncMvcSession]
     jsonSession.id shouldBe testSessionId
 

--- a/test/uk/gov/hmrc/ngc/orchestration/controllers/Setup.scala
+++ b/test/uk/gov/hmrc/ngc/orchestration/controllers/Setup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,27 +60,23 @@ trait Setup {
     "/income/CS700100A/tax-summary/2016" -> true,
     "/income/tax-credits/submission/state/enabled" -> true,
     "/income/CS700100A/tax-credits/tax-credits-summary" -> true,
-    "/income/CS700100A/tax-credits/tax-credits-decision" -> true,
-    "/income/CS700100A/tax-credits/999999999999999/auth" -> true)
+    "/income/CS700100A/tax-credits/tax-credits-decision" -> true)
 
   val maxAgeForPollSuccess = 14400
 
-  lazy val testGenericConnector  = new TestServiceFailureGenericConnector(servicesAuthFailMap ,false, true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
+  lazy val testGenericConnector  = new TestServiceFailureGenericConnector(servicesSuccessMap ,true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
   lazy val authConnector = new TestAuthConnector(Some(nino))
   lazy val testOrchestrationService = new TestOrchestrationService(testGenericConnector, authConnector)
 
-  lazy val testGenericConnectorRETRY  = new TestServiceFailureGenericConnector(servicesSuccessMap ,true, true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
-  lazy val testOrchestrationServiceRETRY = new TestOrchestrationService(testGenericConnectorRETRY, authConnector)
-
-
+  lazy val decisionFailureException:Option[Exception] = None
   val decisionFailure = servicesSuccessMap ++ Map("/income/CS700100A/tax-credits/tax-credits-decision" -> false)
   lazy val testGenericConnectorDecisionFailure  = new TestServiceFailureGenericConnector(decisionFailure,
-    false, true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
+    true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken, None, decisionFailureException)
 
   lazy val testOrchestrationDecisionFailure = new TestOrchestrationService(testGenericConnectorDecisionFailure, authConnector)
 
   def testGenericConnectorFailure(mapping:Map[String, Boolean], exceptionControl:Boolean, httpResponseCode:Option[Int], exception:Option[Exception], taxSummaryData:JsValue): TestServiceFailureGenericConnector =
-    new TestServiceFailureGenericConnector(mapping ,exceptionControl, false, testAccount, TestData.testPushReg, TestData.testPreferences, taxSummaryData,
+    new TestServiceFailureGenericConnector(mapping ,exceptionControl, testAccount, TestData.testPushReg, TestData.testPreferences, taxSummaryData,
       TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken, httpResponseCode, exception)
 
   def testOrchestrationDecisionFailure(mapping:Map[String, Boolean], exceptionControl:Boolean, httpResponseCode:Option[Int], exception:Option[Exception], taxSummaryData:JsValue): (TestOrchestrationService, TestServiceFailureGenericConnector) = {
@@ -93,17 +89,16 @@ trait Setup {
   lazy val testAccessControlOff = AccountAccessControlCheckAccessOff
 
   lazy val servicesStateFailMap = servicesSuccessMap ++ Map("/income/tax-credits/submission/state/enabled" -> false)
-  lazy val testGenericConnectorStateFAILURE = new TestServiceFailureGenericConnector(servicesStateFailMap ,false, true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
+  lazy val testGenericConnectorStateFAILURE = new TestServiceFailureGenericConnector(servicesStateFailMap ,true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
   lazy val testOrchestrationServiceStateFAILURE = new TestOrchestrationService(testGenericConnectorStateFAILURE, authConnector)
 
-  val servicesAuthFailMap: Map[String, Boolean] = servicesSuccessMap ++ Map("/income/CS700100A/tax-credits/999999999999999/auth" -> false)
-  lazy val testGenericConnectorAuthFAILURE = new TestServiceFailureGenericConnector(servicesAuthFailMap ,false, true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
+  lazy val testGenericConnectorAuthFAILURE = new TestServiceFailureGenericConnector(servicesSuccessMap ,true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
   lazy val testOrchestrationServiceAuthFAILURE = new TestOrchestrationService(testGenericConnectorAuthFAILURE, authConnector)
 
-  lazy val testGenericConnectorRenewalSubmissionNotActive = new TestServiceFailureGenericConnector(servicesSuccessMap ,false, true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testStateNotInSubmission, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
+  lazy val testGenericConnectorRenewalSubmissionNotActive = new TestServiceFailureGenericConnector(servicesSuccessMap ,true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testStateNotInSubmission, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
   lazy val testOrchestrationServiceRenewalSubmissionNotActive = new TestOrchestrationService(testGenericConnectorRenewalSubmissionNotActive, authConnector)
 
-  lazy val testGenericConnectorExclusionTrue = new TestServiceFailureGenericConnector(servicesSuccessMap ,false, true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecisionNotDisplay, TestData.testAuthToken)
+  lazy val testGenericConnectorExclusionTrue = new TestServiceFailureGenericConnector(servicesSuccessMap ,true, testAccount, TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecisionNotDisplay, TestData.testAuthToken)
   lazy val testOrchestrationServiceExclusionTrue = new TestOrchestrationService(testGenericConnectorExclusionTrue, authConnector)
 
   val versionBody = Json.parse("""{"os":"android", "version":"1.0.1"}""")
@@ -160,7 +155,7 @@ trait FailurePreFlight extends Setup {
     override def id = "sandbox-async_native-apps-api-id_failure_preflight"
 
     lazy val testGenericConnector  = new TestServiceFailureGenericConnector(
-      servicesSuccessMap ++ Map("/profile/native-app/version-check" -> false) ,false, true, testAccount,
+      servicesSuccessMap ++ Map("/profile/native-app/version-check" -> false) ,true, testAccount,
       TestData.testPushReg, TestData.testPreferences, TestData.taxSummaryData(), TestData.testState,
       TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
     lazy val authConnector = new TestAuthConnector(Some(nino))
@@ -170,26 +165,6 @@ trait FailurePreFlight extends Setup {
     override val accessControlOff: AccountAccessControlWithHeaderCheck = testAccessControlOff
     override val service: OrchestrationService = testOrchestrationService
     override val app: String = "Success Orchestration Controller"
-    override val repository: AsyncRepository = asyncRepository
-    override def checkSecurity: Boolean = true
-    override val auditConnector: AuditConnector = MicroserviceAuditConnector
-    override val maxAgeForSuccess: Long = maxAgeForPollSuccess
-  }
-}
-
-trait AuthenticateRenewal extends Setup {
-  val controller = new NativeAppsOrchestrationController {
-
-    val testSessionId="AuthenticateRenewal"
-    override def buildUniqueId() = testSessionId
-
-    override val actorName = s"async_native-apps-api-actor_"+testSessionId
-    override def id = "async_native-apps-api-id"
-
-    override val accessControl: AccountAccessControlWithHeaderCheck = testCompositeAction
-    override val accessControlOff: AccountAccessControlWithHeaderCheck = testAccessControlOff
-    override val service: OrchestrationService = testOrchestrationServiceAuthFAILURE
-    override val app: String = "AuthenticateRenewal"
     override val repository: AsyncRepository = asyncRepository
     override def checkSecurity: Boolean = true
     override val auditConnector: AuditConnector = MicroserviceAuditConnector
@@ -298,28 +273,12 @@ trait SecurityAsyncSetup extends Setup {
   }
 }
 
-trait FailWithRetrySuccess extends Setup {
-  val controller = new NativeAppsOrchestrationController {
-    val testSessionId="FailWithRetrySuccess"
-    override def buildUniqueId() = testSessionId
-    override val actorName = s"async_native-apps-api-actor_"+testSessionId
-    override def id = "async_native-apps-api-id"
-    override val accessControl: AccountAccessControlWithHeaderCheck = testCompositeAction
-    override val accessControlOff: AccountAccessControlWithHeaderCheck = testAccessControlOff
-    override val service: OrchestrationService = testOrchestrationServiceRETRY
-    override val app: String = "Fail with Retry Success Orchestration Controller"
-    override val repository: AsyncRepository = asyncRepository
-    override def checkSecurity: Boolean = true
-    override val auditConnector: AuditConnector = MicroserviceAuditConnector
-    override val maxAgeForSuccess: Long = maxAgeForPollSuccess
-  }
-
-  def invokeCount = testGenericConnectorRETRY.counter
-}
-
 trait ExclusionException extends Setup {
-  val controller = new NativeAppsOrchestrationController {
-    val testSessionId="ExclusionException"
+
+  val testId:String
+
+  lazy val controller = new NativeAppsOrchestrationController {
+    lazy val testSessionId=testId // "ExclusionException"
     override def buildUniqueId() = testSessionId
     override val actorName = s"async_native-apps-api-actor_"+testSessionId
     override def id = "async_native-apps-api-id"
@@ -332,15 +291,12 @@ trait ExclusionException extends Setup {
     override val auditConnector: AuditConnector = MicroserviceAuditConnector
     override val maxAgeForSuccess: Long = maxAgeForPollSuccess
   }
-
-  def invokeCount = testGenericConnectorRETRY.counter
 }
 
 trait TestGenericController extends Setup {
 
   val time = System.currentTimeMillis()
   val test_id:String
-  val exceptionControl:Boolean
   val exception:Option[Exception]
   val statusCode:Option[Int]
   val mapping:Map[String, Boolean]
@@ -353,7 +309,7 @@ trait TestGenericController extends Setup {
     override def id = "async_native-apps-api-id"
     override val accessControl: AccountAccessControlWithHeaderCheck = testCompositeAction
     override val accessControlOff: AccountAccessControlWithHeaderCheck = testAccessControlOff
-    lazy val testServiceAndConnector: (TestOrchestrationService, TestServiceFailureGenericConnector) = testOrchestrationDecisionFailure(mapping, exceptionControl, statusCode, exception, taxSummaryData)
+    lazy val testServiceAndConnector: (TestOrchestrationService, TestServiceFailureGenericConnector) = testOrchestrationDecisionFailure(mapping, exceptionControl = false, statusCode, exception, taxSummaryData)
     override lazy val service: OrchestrationService = testServiceAndConnector._1
     override val app: String = "Test Generic Controller"
     override val repository: AsyncRepository = asyncRepository
@@ -361,8 +317,6 @@ trait TestGenericController extends Setup {
     override val auditConnector: AuditConnector = MicroserviceAuditConnector
     override val maxAgeForSuccess: Long = maxAgeForPollSuccess
   }
-
-  def invokeCount = testGenericConnectorRETRY.counter
 
   def pushRegistrationInvokeCount = controller.testServiceAndConnector._2.countPushRegistration
 }
@@ -393,11 +347,10 @@ class TestAuthConnector(nino: Option[Nino]) extends AuthConnector {
   override def grantAccess()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Authority] = Future.successful(Authority(nino.getOrElse(Nino("CS700100A")), ConfidenceLevel.L200, "Some Auth-Id"))
 }
 
-class TestServiceFailureGenericConnector(pathFailMap: Map[String, Boolean], exceptionControl: Boolean, upgradeRequired: Boolean, accounts: Accounts, pushRegResult: JsValue,
+class TestServiceFailureGenericConnector(pathFailMap: Map[String, Boolean], upgradeRequired: Boolean, accounts: Accounts, pushRegResult: JsValue,
                                   preferences: JsValue, taxSummary: JsValue, state: JsValue, taxCreditSummary: JsValue,
                                   taxCreditDecision: JsValue, auth: JsValue, httpResponseCode:Option[Int]=None, exception:Option[Exception]=None) extends GenericConnector {
 
-  var counter=0
   var countPushRegistration = 0
 
   override def http: HttpPost with HttpGet = WSHttp
@@ -415,7 +368,7 @@ class TestServiceFailureGenericConnector(pathFailMap: Map[String, Boolean], exce
 
   private def passFail(value: JsValue, success: Boolean): Future[JsValue] = {
     if (!success) {
-      val result = exception.fold(new Exception()){ ex => ex}
+      val result = exception.fold(new Exception("Controlled explosion!")){ ex => ex}
       Future.failed(result)
     } else Future.successful(Json.toJson(value))
   }
@@ -424,39 +377,17 @@ class TestServiceFailureGenericConnector(pathFailMap: Map[String, Boolean], exce
 
   override def doGet(host: String, path: String, port: Int, hc: HeaderCarrier): Future[JsValue] = {
     val result = path match {
-        case "/income/CS700100A/tax-summary/2016" => passFail(taxSummary, isSuccess(path))
-        case "/income/tax-credits/submission/state/enabled" => passFail(state, isSuccess(path))
-        case "/income/CS700100A/tax-credits/tax-credits-summary" => passFail(taxCreditSummary, isSuccess(path))
-        case "/income/CS700100A/tax-credits/tax-credits-decision" =>
-          val res = if (!exceptionControl) passFail(taxCreditDecision, isSuccess(path))
-          else {
-            if (counter == 0) {
-              Future.failed(new ServiceUnavailableException("FAILED"))
-            } else {
-              Future.successful(taxCreditDecision)
-            }
-          }
-          counter = counter + 1
-          res
+      case "/income/CS700100A/tax-summary/2016" => passFail(taxSummary, isSuccess(path))
+      case "/income/tax-credits/submission/state/enabled" => passFail(state, isSuccess(path))
+      case "/income/CS700100A/tax-credits/tax-credits-summary" => passFail(taxCreditSummary, isSuccess(path))
+      case "/income/CS700100A/tax-credits/tax-credits-decision" =>
+          passFail(taxCreditDecision, isSuccess(path))
 
-        case _ => Future.failed(new Exception("Test Scenario Error"))
+        case _ => Future.failed(new Exception(s"Test Scenario Error! The path $path is not defined!"))
       }
     result
   }
 
-  override def doGetRaw(host:String, path:String, port:Int, hc: HeaderCarrier): Future[HttpResponse] = {
-    def isSuccess(key: String): Boolean = pathFailMap.getOrElse(key, false)
-
-    path match {
-      case "/income/CS700100A/tax-credits/999999999999999/auth" =>
-        val res = {
-          if (!isSuccess(path)) {
-            httpResponseCode.fold(401){ code => code }
-          } else 200
-        }
-        Future.successful(HttpResponse(res, Option(auth), Map.empty, Option("")))
-    }
-  }
 }
 
 trait AuthWithoutTaxSummary extends Setup with AuthorityTest {
@@ -473,7 +404,7 @@ trait AuthWithoutTaxSummary extends Setup with AuthorityTest {
   val controller = new NativeAppsOrchestrationController {
     override val accessControl: AccountAccessControlWithHeaderCheck = testCompositeAction
     override val accessControlOff: AccountAccessControlWithHeaderCheck = testAccessControlOff
-    lazy val testCustomerProfileGenericConnector = new TestServiceFailureGenericConnector(servicesAuthFailMap ,false, true, testAccount, TestData.testPushReg, TestData.testPreferences, JsNull, TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
+    lazy val testCustomerProfileGenericConnector = new TestServiceFailureGenericConnector(servicesSuccessMap ,true, testAccount, TestData.testPushReg, TestData.testPreferences, JsNull, TestData.testState, TestData.taxCreditSummaryData, TestData.testTaxCreditDecision, TestData.testAuthToken)
     override val service: OrchestrationService = new TestOrchestrationService(testCustomerProfileGenericConnector, authConnector)
     override val app: String = "AuthWithoutNino Native Apps Orchestration"
     override val repository: AsyncRepository = asyncRepository

--- a/test/uk/gov/hmrc/ngc/orchestration/controllers/StubApplicationConfiguration.scala
+++ b/test/uk/gov/hmrc/ngc/orchestration/controllers/StubApplicationConfiguration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ngc/orchestration/controllers/TestData.scala
+++ b/test/uk/gov/hmrc/ngc/orchestration/controllers/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/ngc/orchestration/controllers/TimedEvent.scala
+++ b/test/uk/gov/hmrc/ngc/orchestration/controllers/TimedEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The following updates have been made. 

1) Drop auth/999 service since does not work for all customers. 
2) Only use the Exclusion service to drive the decision if customer is eligible for tax-credits. 
3) Drop the retry function since no longer required. The backend will re-try the request to the HOD on failure. 
4) Add logging around 401 responses to tax-credit services. 