### PR TITLE
NGC-1494 - Add journey Id + re-sync auth connector.

### DIFF
--- a/app/uk/gov/hmrc/ngc/orchestration/controllers/action/AccountAccessControl.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/controllers/action/AccountAccessControl.scala
@@ -19,63 +19,76 @@ package uk.gov.hmrc.ngc.orchestration.controllers.action
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc._
-import uk.gov.hmrc.api.controllers.{ErrorAcceptHeaderInvalid, ErrorUnauthorized, ErrorUnauthorizedLowCL, HeaderValidator}
+import uk.gov.hmrc.api.controllers._
+import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.auth.microservice.connectors.ConfidenceLevel
 import uk.gov.hmrc.play.http._
 import uk.gov.hmrc.play.http.hooks.HttpHook
-import uk.gov.hmrc.ngc.orchestration.connectors.{AccountWithLowCL, AuthConnector, Authority, NinoNotFoundOnAccount}
-import uk.gov.hmrc.ngc.orchestration.controllers.{ErrorUnauthorizedNoNino, ForbiddenAccess}
+import uk.gov.hmrc.ngc.orchestration.connectors._
+import uk.gov.hmrc.ngc.orchestration.controllers.ErrorUnauthorizedNoNino
 
 import scala.concurrent.Future
 
 
 case class AuthenticatedRequest[A](authority: Option[Authority], request: Request[A]) extends WrappedRequest(request)
 
-trait AccountAccessControl extends ActionBuilder[AuthenticatedRequest] with Results {
+case object ErrorUnauthorizedMicroService extends ErrorResponse(401, "UNAUTHORIZED", "Unauthorized to access resource")
+case object ErrorUnauthorizedWeakCredStrength extends ErrorResponse(401, "WEAK_CRED_STRENGTH", "Credential Strength on account does not allow access")
+
+trait AccountAccessControl extends Results {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
   val authConnector: AuthConnector
 
-  def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]) = {
-    implicit val hc = HeaderCarrier.fromHeadersAndSession(request.headers, None)
+  case object ErrorUnauthorized extends ErrorResponse(401, "UNAUTHORIZED", "Invalid request")
 
-    authConnector.grantAccess().flatMap {
-      authority => {
-        block(AuthenticatedRequest(Some(authority),request))
-      }
+    def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result], taxId:Option[Nino]) = {
+      implicit val hc = HeaderCarrier.fromHeadersAndSession(request.headers, None)
+        authConnector.grantAccess(taxId).flatMap {
+          authority => {
+            block(AuthenticatedRequest(Some(authority), request))
+          }
     }.recover {
-      case ex:uk.gov.hmrc.play.http.Upstream4xxResponse => Unauthorized(Json.toJson(ErrorUnauthorized))
+      case ex: uk.gov.hmrc.play.http.Upstream4xxResponse =>
+        Logger.info("Unauthorized! Failed to grant access since 4xx response!")
+        Unauthorized(Json.toJson(ErrorUnauthorizedMicroService))
 
-      case ex:ForbiddenException =>
-        Logger.info("Unauthorized! ForbiddenException caught and returning 403 status!")
-        Forbidden(Json.toJson(ForbiddenAccess))
-
-      case ex:NinoNotFoundOnAccount =>
+      case ex: NinoNotFoundOnAccount =>
         Logger.info("Unauthorized! NINO not found on account!")
         Unauthorized(Json.toJson(ErrorUnauthorizedNoNino))
 
-      case ex:AccountWithLowCL =>
+      case ex: FailToMatchTaxIdOnAuth =>
+        Logger.info("Unauthorized! Failure to match URL NINO against Auth NINO")
+        Status(ErrorUnauthorized.httpStatusCode)(Json.toJson(ErrorUnauthorized))
+
+      case ex: AccountWithLowCL =>
         Logger.info("Unauthorized! Account with low CL!")
         Unauthorized(Json.toJson(ErrorUnauthorizedLowCL))
+
+      case ex: AccountWithWeakCredStrength =>
+        Logger.info("Unauthorized! Account with weak cred strength!")
+        Unauthorized(Json.toJson(ErrorUnauthorizedWeakCredStrength))
     }
   }
+
 }
 
 trait AccountAccessControlWithHeaderCheck extends HeaderValidator {
   val checkAccess=true
   val accessControl:AccountAccessControl
 
-  override def validateAccept(rules: Option[String] => Boolean) = new ActionBuilder[AuthenticatedRequest] {
+    def validateAcceptWithAuth(rules: Option[String] => Boolean, taxId: Option[Nino]) = new ActionBuilder[AuthenticatedRequest] {
 
-    def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]) = {
-      if (rules(request.headers.get("Accept"))) {
-        if (checkAccess) accessControl.invokeBlock(request, block)
-        else block(AuthenticatedRequest(None,request))
+      def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]) = {
+        if (rules(request.headers.get("Accept"))) {
+          if (checkAccess) accessControl.invokeBlock(request, block, taxId)
+          else block(AuthenticatedRequest(None,request))
+        }
+        else Future.successful(Status(ErrorAcceptHeaderInvalid.httpStatusCode)(Json.toJson(ErrorAcceptHeaderInvalid)))
       }
-      else Future.successful(Status(ErrorAcceptHeaderInvalid.httpStatusCode)(Json.toJson(ErrorAcceptHeaderInvalid)))
     }
-  }
+
 }
 
 object Auth {
@@ -90,7 +103,7 @@ object AccountAccessControlWithHeaderCheck extends AccountAccessControlWithHeade
   val accessControl: AccountAccessControl = AccountAccessControl
 }
 
-object AccountAccessControlSandbox extends AccountAccessControl {
+object AccountAccessControlOff extends AccountAccessControl {
   val authConnector: AuthConnector = new AuthConnector {
     override val serviceUrl: String = "NO SERVICE"
 
@@ -103,8 +116,9 @@ object AccountAccessControlSandbox extends AccountAccessControl {
   }
 }
 
-object AccountAccessControlCheckAccessOff extends AccountAccessControlWithHeaderCheck {
+object AccountAccessControlCheckOff extends AccountAccessControlWithHeaderCheck {
   override val checkAccess=false
 
-  val accessControl: AccountAccessControl = AccountAccessControlSandbox
+  val accessControl: AccountAccessControl = AccountAccessControlOff
 }
+

--- a/app/uk/gov/hmrc/ngc/orchestration/domain/CredentialStrength.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/domain/CredentialStrength.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ngc.orchestration.domain
+
+import play.api.libs.json._
+
+sealed abstract class CredentialStrength(val name: String)
+
+object CredentialStrength {
+
+  case object Strong extends CredentialStrength("strong")
+  case object Weak extends CredentialStrength("weak")
+  case object None extends CredentialStrength("none")
+
+  val fromName: String => CredentialStrength = Seq(Strong, Weak, None).map(c => c.name -> c).toMap
+
+  implicit val format = {
+    val reads = new Reads[CredentialStrength] {
+      override def reads(json: JsValue) =
+        try {
+          JsSuccess(fromName(json.as[String]))
+        } catch {
+          case _ : Throwable => JsError()
+        }
+    }
+    val writes = new Writes[CredentialStrength] {
+      override def writes(o: CredentialStrength) = new JsString(o.name)
+    }
+    Format(reads, writes)
+  }
+
+}

--- a/app/uk/gov/hmrc/ngc/orchestration/services/Executor.scala
+++ b/app/uk/gov/hmrc/ngc/orchestration/services/Executor.scala
@@ -140,17 +140,8 @@ case class TaxCreditSummary(authConnector:AuthConnector, connector: GenericConne
   private def handle4xxException(ex:Upstream4xxResponse)(implicit hc: HeaderCarrier): Unit = {
     if (ex.upstreamResponseCode==401) {
       Logger.warn(s"${logJourneyId(journeyId)} - 401 returned for tax-credits-decision!")
-      logAuth(journeyId)
     } else {
       Logger.warn(s"${logJourneyId(journeyId)} - ${ex.upstreamResponseCode} returned for tax-credits-decision.")
-    }
-  }
-
-  protected def logAuth(journeyId: Option[String])(implicit hc: HeaderCarrier) = {
-    authConnector.grantAccess().map(res => {
-      Logger.warn(s"${logJourneyId(journeyId)} Authority record is good for ${journeyId} for HC ${hc.authorization}!")
-    }).recover {
-      case ex: Exception => Logger.error(s"Failed to verify the authority record! Exception is ${ex.getMessage} for journey ID $journeyId")
     }
   }
 

--- a/conf/live.routes
+++ b/conf/live.routes
@@ -1,6 +1,6 @@
 # microservice specific routes
 
-POST        /native-app/preflight-check        uk.gov.hmrc.ngc.orchestration.controllers.LiveOrchestrationController.preFlightCheck()
+POST        /native-app/preflight-check        uk.gov.hmrc.ngc.orchestration.controllers.LiveOrchestrationController.preFlightCheck(journeyId: Option[String])
 
 POST        /native-app/:nino/startup          uk.gov.hmrc.ngc.orchestration.controllers.LiveOrchestrationController.startup(nino: uk.gov.hmrc.domain.Nino, journeyId: Option[String])
 

--- a/conf/sandbox.routes
+++ b/conf/sandbox.routes
@@ -1,6 +1,6 @@
 # microservice specific routes
 
-POST       /native-app/preflight-check    uk.gov.hmrc.ngc.orchestration.controllers.SandboxOrchestrationController.preFlightCheck()
+POST       /native-app/preflight-check    uk.gov.hmrc.ngc.orchestration.controllers.SandboxOrchestrationController.preFlightCheck(journeyId: Option[String])
 
 POST       /native-app/:nino/startup      uk.gov.hmrc.ngc.orchestration.controllers.SandboxOrchestrationController.startup(nino: uk.gov.hmrc.domain.Nino, journeyId: Option[String])
 

--- a/docs/preflight-check.md
+++ b/docs/preflight-check.md
@@ -9,7 +9,9 @@ preflight-check
   
 * **URL**
 
-  `/native-app/preflight-check`
+  `/native-app/preflight-check?journeyId=1234`
+
+    The journeyId is optional. Supplying the journeyId will default the response journeyId.
 
 * **Method:**
   

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -51,7 +51,7 @@ uses:
       /startup:
         post:
           displayName: Startup async
-          description: This endpoint retrieves the personal tax data asynchronously and registers the device notification token. The /poll service must be invoked to obtain the respnose to this service.
+          description: This endpoint retrieves the personal tax data asynchronously and registers the device notification token. The /poll service must be invoked to obtain the response to this service.
           is: [headers.acceptHeader]
           (annotations.scope): "read:personal-income"
           securedBy: [ sec.oauth_2_0: { scopes: [ "read:personal-income" ] } ]

--- a/resources/public/api/conf/1.0/docs/overview.md
+++ b/resources/public/api/conf/1.0/docs/overview.md
@@ -1,2 +1,2 @@
 ### What is this API for?
-The API is used to consolidate calls across multiple micro-services to two single API calls.
+Expose asynchronous services to the mobile application where the client does not block for a response. The client initiates the request and then polls back to the server to retrive the response.

--- a/resources/public/api/conf/1.0/docs/overview.md
+++ b/resources/public/api/conf/1.0/docs/overview.md
@@ -1,2 +1,2 @@
 ### What is this API for?
-Expose asynchronous services to the mobile application where the client does not block for a response. The client initiates the request and then polls back to the server to retrive the response.
+Expose asynchronous services to the mobile application where the client does not block for a response. The client initiates the request and then polls back to the server to retrieve the response.

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -8,7 +8,7 @@
   ],
   "api":{
     "name":"Native Apps API Orchestration",
-    "description":"The API is used to consolidate calls across multiple micro-services to two single API calls.",
+    "description":"Expose asynchronous services to the mobile application where the client does not block for a response. The client initiates the request and then polls back to the server to retrive the response.",
     "context":"native-apps-api-orchestration",
     "requiresTrust": true,
     "versions":[

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -8,7 +8,7 @@
   ],
   "api":{
     "name":"Native Apps API Orchestration",
-    "description":"Expose asynchronous services to the mobile application where the client does not block for a response. The client initiates the request and then polls back to the server to retrive the response.",
+    "description":"Expose asynchronous services to the mobile application where the client does not block for a response. The client initiates the request and then polls back to the server to retrieve the response.",
     "context":"native-apps-api-orchestration",
     "requiresTrust": true,
     "versions":[

--- a/test/uk/gov/hmrc/ngc/orchestration/connectors/AuthConnectorSpec.scala
+++ b/test/uk/gov/hmrc/ngc/orchestration/connectors/AuthConnectorSpec.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ngc.orchestration.connectors
+
+import org.scalatest.concurrent.ScalaFutures
+import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.domain.{Nino, SaUtr}
+import uk.gov.hmrc.ngc.orchestration.domain.CredentialStrength
+import uk.gov.hmrc.play.auth.microservice.connectors.ConfidenceLevel
+import uk.gov.hmrc.play.http.hooks.HttpHook
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpResponse}
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+class AuthConnectorSpec extends UnitSpec with ScalaFutures {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  implicit val hc = HeaderCarrier()
+
+  def authConnector(response : HttpResponse, cl: ConfidenceLevel = ConfidenceLevel.L200) = new AuthConnector {
+
+    override def uuid = "some_value"
+
+    override def http: HttpGet = new HttpGet {
+      override protected def doGet(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = Future.successful(response)
+
+      override val hooks: Seq[HttpHook] = Seq.empty
+    }
+
+    override val serviceUrl: String = "http://localhost"
+
+    override def serviceConfidenceLevel: ConfidenceLevel = cl
+  }
+
+  "Returning the accounts" should {
+
+    "find the user and routeToIV and routeToTwoFactor should be true" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L50
+      val credentialStrength = CredentialStrength.Weak
+
+      val saUtr = Some(SaUtr("1872796160"))
+      val nino = Some(Nino("CS100700A"))
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      val accounts = await(authConnector(response, serviceConfidenceLevel).accounts(Some("id")))
+
+      accounts.nino.get shouldBe nino.get
+      accounts.saUtr.get shouldBe saUtr.get
+      accounts.routeToIV shouldBe true
+      accounts.routeToTwoFactor shouldBe true
+      accounts.journeyId shouldBe "id"
+    }
+
+    "find the user and routeToIV is false and routeToTwoFactor is true" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L50
+      val credentialStrength = CredentialStrength.Strong
+
+      val saUtr = Some(SaUtr("1872796160"))
+      val nino = Some(Nino("CS100700A"))
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      val accounts = await(authConnector(response, serviceConfidenceLevel).accounts(Some("id")))
+
+      accounts.nino.get shouldBe nino.get
+      accounts.saUtr.get shouldBe saUtr.get
+      accounts.routeToIV shouldBe true
+      accounts.routeToTwoFactor shouldBe false
+      accounts.journeyId shouldBe "id"
+    }
+
+    "ignore the supplied journeyId when blank" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L50
+      val credentialStrength = CredentialStrength.Strong
+
+      val saUtr = Some(SaUtr("1872796160"))
+      val nino = Some(Nino("CS100700A"))
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      val accounts = await(authConnector(response, serviceConfidenceLevel).accounts(Some("")))
+
+      accounts.nino.get shouldBe nino.get
+      accounts.saUtr.get shouldBe saUtr.get
+      accounts.routeToIV shouldBe true
+      accounts.routeToTwoFactor shouldBe false
+      accounts.journeyId shouldBe "some_value"
+    }
+
+    "find the user and routeToIV and routeToTwoFactor should be false" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L200
+      val credentialStrength = CredentialStrength.Strong
+
+      val saUtr = Some(SaUtr("1872796160"))
+      val nino = Some(Nino("CS100700A"))
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      val accounts = await(authConnector(response, serviceConfidenceLevel).accounts(Some("id")))
+
+      accounts.nino.get shouldBe nino.get
+      accounts.saUtr.get shouldBe saUtr.get
+      accounts.routeToIV shouldBe false
+      accounts.routeToTwoFactor shouldBe false
+      accounts.journeyId shouldBe "id"
+    }
+
+    "find the user when the users account does not have a NINO" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L200
+      val credentialStrength = CredentialStrength.Strong
+
+      val saUtr = Some(SaUtr("1872796160"))
+      val nino = None
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      val accounts = await(authConnector(response, serviceConfidenceLevel).accounts(Some("id")))
+
+      accounts.nino shouldBe None
+      accounts.saUtr.get shouldBe saUtr.get
+      accounts.routeToIV shouldBe false
+      accounts.routeToTwoFactor shouldBe false
+      accounts.journeyId shouldBe "id"
+    }
+
+  }
+
+  "grantAccess" should {
+
+    "error with unauthorised when account has low CL" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L50
+      val credentialStrength = CredentialStrength.Weak
+      val saUtr = Some(SaUtr("1872796160"))
+      val nino = None
+
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      try {
+        await(authConnector(response, serviceConfidenceLevel).grantAccess(nino))
+      } catch {
+        case e: AccountWithLowCL =>
+          e.message shouldBe "The user does not have sufficient CL permissions to access this service"
+        case t: Throwable =>
+          fail("Unexpected error failure")
+      }
+    }
+
+    "fail to find Nino only accounts when credStrength is weak" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L200
+      val credentialStrength = CredentialStrength.Weak
+      val saUtr = None
+      val nino = Some(Nino("CS100700A"))
+
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      try {
+        await(authConnector(response, serviceConfidenceLevel).grantAccess(nino))
+      } catch {
+        case e: AccountWithWeakCredStrength =>
+          e.message shouldBe "The user does not have sufficient credential strength permissions to access this service"
+        case t: Throwable =>
+          fail("Unexpected error failure with exception " + t)
+      }
+    }
+
+    "successfully return account with NINO when SAUTR is empty" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L200
+      val credentialStrength = CredentialStrength.Strong
+
+      val saUtr = Some(SaUtr("1872796160"))
+      val nino = Some(Nino("CS100700A"))
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      await(authConnector(response, serviceConfidenceLevel).grantAccess(nino))
+    }
+
+    "find NINO only account when credStrength and CL are correct" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L200
+      val credentialStrength = CredentialStrength.Strong
+      val saUtr = None
+      val nino = Some(Nino("CS100700A"))
+
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      await(authConnector(response, serviceConfidenceLevel).grantAccess(nino))
+
+    }
+
+    "fail to return authority when no NINO exists" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L200
+      val credentialStrength = CredentialStrength.Strong
+      val saUtr = None
+      val nino = None
+
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, nino)))
+
+      try {
+        await(authConnector(response, serviceConfidenceLevel).grantAccess(nino))
+      } catch {
+        case e: NinoNotFoundOnAccount =>
+          e.message shouldBe "The user must have a National Insurance Number"
+        case t: Throwable =>
+          fail("Unexpected error failure with exception " + t)
+      }
+    }
+
+    "fail to return authority when auth NINO does not match request NINO" in {
+
+      val serviceConfidenceLevel = ConfidenceLevel.L200
+      val authorityConfidenceLevel = ConfidenceLevel.L200
+      val credentialStrength = CredentialStrength.Strong
+      val saUtr = None
+      val ninoAuth = Some(Nino("CS100700A"))
+      val ninoRequest = Some(Nino("CS333700A"))
+
+      val response = HttpResponse(200, Some(authorityJson(authorityConfidenceLevel, credentialStrength, saUtr, ninoAuth)))
+
+      try {
+        await(authConnector(response, serviceConfidenceLevel).grantAccess(ninoRequest))
+      } catch {
+        case e: FailToMatchTaxIdOnAuth =>
+          e.message shouldBe "The nino in the URL failed to match auth!"
+        case t: Throwable =>
+          fail("Unexpected error failure with exception " + t)
+      }
+    }
+
+
+  }
+
+  def authorityJson(confidenceLevel: ConfidenceLevel, credStrength:CredentialStrength, saUtr: Option[SaUtr], nino : Option[Nino]): JsValue = {
+
+    val sa : String = saUtr match {
+      case Some(utr) => s"""
+                          | "sa": {
+                          |            "link": "/sa/individual/$utr",
+                          |            "utr": "$utr"
+                          |        },
+                        """.stripMargin
+      case None => ""
+    }
+
+    val paye = nino match {
+      case Some(n) => s"""
+                          "paye": {
+                          |            "link": "/paye/individual/$n",
+                          |            "nino": "$n"
+                          |        },
+                        """.stripMargin
+      case None => ""
+    }
+
+    val json =
+      s"""
+         |{
+         |    "uri" : "someuri",
+         |    "accounts": {
+         |       $sa
+         |       $paye
+         |        "ct": {
+         |            "link": "/ct/8040200779",
+         |            "utr": "8040200779"
+         |        },
+         |        "vat": {
+         |            "link": "/vat/999904829",
+         |            "vrn": "999904829"
+         |        },
+         |        "epaye": {
+         |            "link": "/epaye/754%2FMODES02",
+         |            "empRef": "754/MODES02"
+         |        }
+         |    },
+         |    "confidenceLevel": ${confidenceLevel.level},
+         |    "credentialStrength": "${credStrength.name}"
+         |}
+      """.stripMargin
+
+    Json.parse(json)
+  }
+}


### PR DESCRIPTION
Following updates have been made. 

1. Allow the journeyId to be supplied to the preflight service. 
2. Re-sync the AuthConnector.
3. Add tests for AuthConnector. 